### PR TITLE
Update copyright year to 2026

### DIFF
--- a/.vitepress/theme/Layout.vue
+++ b/.vitepress/theme/Layout.vue
@@ -61,7 +61,7 @@ const repositoryLabel = computed(() => {
           </div>
           <div class="mt-4">
             <p>
-              © 2024
+              © 2026
               <a
                 class="text-blue-500 hover:text-blue"
                 :href="`https://x.com/${theme.x}`"


### PR DESCRIPTION
Update the copyright year in the footer from 2024 to 2026.